### PR TITLE
ci: fix pnpm install failure by migrating config to pnpm 10

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/package.json
+++ b/package.json
@@ -44,13 +44,6 @@
   "overrides": {
     "vite": "^7"
   },
-  "pnpm": {
-    "peerDependencyRules": {
-      "allowedVersions": {
-        "tsconfck>typescript": "6"
-      }
-    }
-  },
   "devDependencies": {
     "@astrojs/check": "^0.9.9",
     "typescript": "^6.0.3"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,11 @@
 allowBuilds:
   esbuild: true
   sharp: true
+
+onlyBuiltDependencies:
+  - esbuild
+  - sharp
+
+peerDependencyRules:
+  allowedVersions:
+    tsconfck>typescript: "6"


### PR DESCRIPTION
The GitHub Pages deploy workflow was failing on every push to master: `actions/setup-node`'s pnpm cache step ran `pnpm store path`, which errored with `packages field missing or empty` because `pnpm-workspace.yaml` existed without a `packages:` field. Deploys are unblocked now — the workflow installs on pnpm 10 and native build scripts for `esbuild` and `sharp` actually run.

Settings moved out of `package.json`'s `pnpm` field (no longer read by pnpm 10+) into `pnpm-workspace.yaml`, joining `onlyBuiltDependencies` and the existing `allowBuilds` approval ledger that pnpm 11's `approve-builds` writes.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_%281M%29-D97757?logo=claude&logoColor=white)
